### PR TITLE
Allow _unsafeUnwrapErr

### DIFF
--- a/src/rules/must-use-result.ts
+++ b/src/rules/must-use-result.ts
@@ -25,7 +25,12 @@ const resultProperties = [
   'unwrapOr',
 ];
 
-const handledMethods = ['match', 'unwrapOr', '_unsafeUnwrap'];
+const handledMethods = [
+  'match',
+  'unwrapOr',
+  '_unsafeUnwrap',
+  '_unsafeUnwrapErr',
+];
 
 // evalua dentro de la expresion si es result
 // si es result chequea que sea manejada en el la expresion
@@ -194,7 +199,7 @@ const rule: TSESLint.RuleModule<MessageIds, []> = {
     },
     messages: {
       mustUseResult:
-        'Result must be handled with either of match, unwrapOr or _unsafeUnwrap.',
+        'Result must be handled with either of match, unwrapOr, _unsafeUnwrap or _unsafeUnwrapErr.',
     },
     schema: [],
     type: 'problem',

--- a/tests/rules/must-use.ts
+++ b/tests/rules/must-use.ts
@@ -95,6 +95,22 @@ new TSESLint.RuleTester({
     `
     ),
     injectResult(
+      'call _unsafeUnwrap after some methods',
+      `
+      const result = getResult()
+
+      result.map(() => {})._unsafeUnwrap('')
+    `
+    ),
+    injectResult(
+      'call _unsafeUnwrapErr after some methods',
+      `
+      const result = getResult()
+
+      result.map(() => {})._unsafeUnwrapErr('')
+    `
+    ),
+    injectResult(
       'Call match',
       `
       const result = getResult()


### PR DESCRIPTION
This change will allow `_unsafeUnwrapErr` to be a valid way of consuming the result. The rule already allows `_unsafeUnwrap`.

This change is needed because currently there is no simple way to assert an error message in a unit test for example. When using `_unsafeUnwrapErr`, the linter shows this message:

> Result must be handled with either of match, unwrapOr or _unsafeUnwrap. _eslint:neverthrow/must-use-result_

To avoid this, I had to do this in unit tests:

```ts
let error: Error = new Error();
result.match(
  () => {},
  (e) => {
     error = e;
});
expect(error.message).toBe("The object is missing");
```
Which is a lot of boilerplate for a small assertion. 

Using `_unsafeUnwrap` will obviously not work with an Err.

Other changes:
* Added a couple of unit tests for `_unsafeUnwrap` and `_unsafeUnwrapErr`.
* Updated the linting message.